### PR TITLE
Changed shebang to #!/usr/bin/python

### DIFF
--- a/get_vcenter_id.py
+++ b/get_vcenter_id.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 #  Copyright 2015 VMware, Inc.
 #

--- a/nsxconfig.py
+++ b/nsxconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 try:
     import json

--- a/set_vcsa_sh.py
+++ b/set_vcsa_sh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 #  Copyright 2015 VMware, Inc.
 #

--- a/vcenter_add_nfs_ds.py
+++ b/vcenter_add_nfs_ds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 DOCUMENTATION = '''
 module: vcenter_add_nfs_ds

--- a/vcenter_addhost.py
+++ b/vcenter_addhost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #  Copyright 2015 VMware, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/vcenter_addvmk.py
+++ b/vcenter_addvmk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 DOCUMENTATION = '''
 module: vcenter_addvmk

--- a/vcenter_cluster.py
+++ b/vcenter_cluster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #  Copyright 2015 VMware, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/vcenter_config_host_vds_only.py
+++ b/vcenter_config_host_vds_only.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 #  Copyright 2015 VMware, Inc.
 #

--- a/vcenter_datacenter.py
+++ b/vcenter_datacenter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #  Copyright 2015 VMware, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/vcenter_query.py
+++ b/vcenter_query.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 #  Copyright 2015 VMware, Inc.
 #


### PR DESCRIPTION
Regarding the Ansible documentation http://docs.ansible.com/ansible/developing_modules.html#module-checklist the "The shebang should always be #!/usr/bin/python, this allows ansible_python_interpreter to work". 

This pull request changes shebang for all Ansible Python modules. I tested vcenter_datacenter.py on my local env with ansible_python_interpreter property.    
