### PR TITLE
Fix issue with searching across multiple data centers

### DIFF
--- a/does_vm_exist.py
+++ b/does_vm_exist.py
@@ -53,7 +53,7 @@ def main():
             for virtual_machine in vm_list:
                 check_vm_and_children(vm_name, virtual_machine, 1, module)
 
-            module.exit_json(msg="Appliance does not exist.")
+        module.exit_json(msg="Appliance does not exist.")
 
     except vmodl.MethodFault as error:
         module.fail_json(msg="vmodl.MethodFault")


### PR DESCRIPTION
Currently only the first data center folder is searched for vmname. module.exit_json is within the for loop. Moving it out of the loop allows searching multiple data centers.
