### PR TITLE
Add utility modules for NSX-T

### DIFF
--- a/nsxt/nsxt_controller_details.py
+++ b/nsxt/nsxt_controller_details.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_controller_details.py
+++ b/nsxt/nsxt_controller_details.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#__author__ = 'VJ49'
+
+import yaml
+import yamlordereddictloader
+from collections import OrderedDict
+
+import logging
+logger = logging.getLogger('nsxt_controller_details')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+        ),
+        supports_check_mode=True
+    )
+    final_dict = {}
+    main_list = list()
+    main_dict = {}
+    stream = open('/var/lib/chaperone/answerfile.yml', 'r')    
+    dict1 = yaml.load(stream, Loader=yamlordereddictloader.Loader)
+    try:
+        for key in dict1:
+            if key.startswith('nsx_controller') == True:
+                if "host_name" in key:
+                    main_dict["display_name"]=dict1[key]
+            	if "ip" in key: 
+                    main_dict["ip_address"]=dict1[key] 
+
+                    logger.info(main_dict)
+                    main_list.append(main_dict)
+                    main_dict= {}    
+        logger.info(main_list)
+        logger.info(main_dict)            
+
+        final_dict['Controller_nodes']=main_list
+	module.exit_json(changed=True, result=final_dict, msg= "Successfully got the Controller Node information")
+    except Exception as err:
+        module.fail_json(changed=False, msg= "Failure: %s" %(err))
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/nsxt/nsxt_controller_details.py
+++ b/nsxt/nsxt_controller_details.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#__author__ = 'VJ49'
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_edge_details.py
+++ b/nsxt/nsxt_edge_details.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_edge_details.py
+++ b/nsxt/nsxt_edge_details.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#__author__ = 'VJ49'
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_edge_details.py
+++ b/nsxt/nsxt_edge_details.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#__author__ = 'VJ49'
+
+import yaml
+import yamlordereddictloader
+from collections import OrderedDict
+
+import logging
+logger = logging.getLogger('vswitch')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+        ),
+        supports_check_mode=True
+    )
+    final_dict = {}
+    main_list = list()
+    main_dict = {}
+    stream = open('/var/lib/chaperone/answerfile.yml', 'r')    
+    dict1 = yaml.load(stream, Loader=yamlordereddictloader.Loader)
+    try:
+        for key in dict1:
+            if key.startswith('nsx_edge') == True:
+                if "host_name" in key:
+                    main_dict["display_name"]=dict1[key]
+            	if "ip" in key:
+                    main_dict["ip_address"]=dict1[key]
+                    main_list.append(main_dict)
+                    main_dict= {}
+            logger.info(main_dict)
+        logger.info(main_list)
+        logger.info(main_dict)            
+
+        final_dict['Edge_nodes']=main_list
+	module.exit_json(changed=True, result=final_dict, msg= "Successfully got the information")
+
+
+    except Exception as err:
+        module.fail_json(changed=False, msg= "Failure: %s" %(err))
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/nsxt/nsxt_fabric_details.py
+++ b/nsxt/nsxt_fabric_details.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_fabric_details.py
+++ b/nsxt/nsxt_fabric_details.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#__author__ = 'VJ49'
+
+import yaml
+import yamlordereddictloader
+from collections import OrderedDict
+
+import paramiko
+import time
+from pyVmomi import vim, vmodl
+from pyVim import connect
+from pyVim.connect import SmartConnect, SmartConnectNoSSL
+
+import logging
+logger = logging.getLogger('nsxt_fabric_details')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+def getting_thumbprint(module,pi):      
+    try:         
+        command = "openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout"
+        (sshin1, sshout1, ssherr1) = pi.exec_command(command)
+        out = sshout1.read()
+        output = out.split("=")[1]
+        logger.info(output)
+        return output.rstrip("\n")    
+    except Exception as error:
+       	logger.info("Error Occured:%s" %(error))
+        module.fail_json(msg="Error Occured: %s" %error)
+	
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+        ),
+        supports_check_mode=True
+    )
+    username = "root"
+    final_dict = {}
+    main_list = list()
+    main_dict = {}
+    stream = open('/var/lib/chaperone/answerfile.yml', 'r')    
+    dict1 = yaml.load(stream, Loader=yamlordereddictloader.Loader)
+    try:
+        for key in dict1:
+            if key.startswith('esxi_compute') == True:
+            	if "ip" in key:
+                    main_dict["display_name"]=dict1[key]
+                    main_dict["ip_address"]=dict1[key]
+                    logger.info(main_dict)
+                if "os_version" in key:
+                    main_dict["os_version"]=dict1[key]
+                if "password" in key:
+                    main_dict["host_password"]=dict1[key]
+                    logger.info(main_dict)
+
+                    main_list.append(main_dict)
+                    logger.info(main_dict)
+                    logger.info(main_list)                  
+                    main_dict={}      
+        logger.info(main_list)           
+        pi = paramiko.client.SSHClient()
+        pi.load_system_host_keys()
+        pi.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
+        for i in range(0,len(main_list)):
+            logger.info(main_list[i]["ip_address"])           
+            pi.connect(main_list[i]["ip_address"], 22, username, main_list[i]["host_password"])
+	    logger.info('Esxi host connection succeed...........')
+	    thumb_prints= getting_thumbprint(module,pi)
+	    main_list[i]["host_thumbprint"]=thumb_prints
+        logger.info(main_list)
+        final_dict['fabric_host_nodes']=main_list
+        module.exit_json(changed=True, result=final_dict, msg= "Successfully got the Fabric Host Nodes information")
+
+    except Exception as err:
+        module.fail_json(changed=False, msg= "Failure: %s" %(err))
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/nsxt/nsxt_fabric_details.py
+++ b/nsxt/nsxt_fabric_details.py
@@ -1,22 +1,19 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#__author__ = 'VJ49'
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_selfsigned.py
+++ b/nsxt/nsxt_selfsigned.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2016 VMware, Inc.  All rights reserved.
+
+# Portions Copyright (c) 2015 VMware, Inc. All rights reserved.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import paramiko
+import string
+import pyVim.task
+
+
+from pyVmomi import vim, vmodl
+from pyVim import connect
+from pyVim.connect import SmartConnect, SmartConnectNoSSL
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+
+import logging
+logger = logging.getLogger('nsxt_selfsigned_cert')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+headers = dict(Accept="application/json")
+headers['Content-Type'] = 'application/json'
+
+create_cert = """openssl req -newkey rsa:2048 -x509 -nodes -keyout nsx.key -new -out nsx.crt -subj /CN=$NSX_MANAGER_COMMONNAME -reqexts SAN -extensions SAN -config <(cat /opt/chaperone-ansible/roles/nsxt/defaults/nsx-cert.cnf \
+ <(printf "[SAN]\nsubjectAltName=DNS:$NSX_MANAGER_COMMONNAME,IP:$NSX_MANAGER_IP_ADDRESS")) -sha256 -days 365"""
+
+
+verify_cert = """openssl x509 -in nsx.crt -text -noout"""
+
+
+search_pemcode = """awk '{printf "%s\\n", $0}' /home/vmware/nsx.crt"""
+
+search_private_key= """awk '{printf "%s\\n", $0}' /home/vmware/nsx.key"""
+
+register_cert = """curl --insecure -u admin:'admin_pw' -X POST 'https://NSX-Manager-IP-Address/api/v1/node/services/http?action=apply_certificate&certificate_id=CERTIFICATE-ID' """
+
+def Self_Signed_Cert(pi,module,request_data,NSX_MANAGER_COMMONNAME,NSX_MANAGER_IP_ADDRESS,NSX_USER,NSX_PASSWORD,validate_certs,cert_name,manager_url):
+    #create_cert1 = string.replace(create_cert, "$NSX_MANAGER_IP_ADDRESS",NSX_MANAGER_IP_ADDRESS)
+    create_cert1 = string.replace(create_cert, "$NSX_MANAGER_IP_ADDRESS",NSX_MANAGER_IP_ADDRESS)
+    create_cert2 = string.replace(create_cert1, "$NSX_MANAGER_COMMONNAME",NSX_MANAGER_COMMONNAME)
+    logger.info(create_cert2) 
+    register_cert1 = string.replace(register_cert, "admin_pw" , NSX_PASSWORD)
+    register_cert2 = string.replace(register_cert1, "NSX-Manager-IP-Address", NSX_MANAGER_IP_ADDRESS)
+    
+    try:
+        (sshin1, sshout1, ssherr1) = pi.exec_command(create_cert2)          
+        output = sshout1.read()
+        output1 = ssherr1.read()
+        logger.info(output)
+        logger.info(output1)
+		
+        (sshin2, sshout2, ssherr2) = pi.exec_command(verify_cert)
+        logger.info(sshout2.read())
+        logger.info(search_pemcode)
+        (sshin3, sshout3, ssherr3) = pi.exec_command(search_pemcode)
+        pem_encoded=sshout3.read()
+        logger.info(pem_encoded)        
+        (sshin4, sshout4, ssherr4) = pi.exec_command(search_private_key)
+        private_key =sshout4.read()
+
+        request_data["pem_encoded"] = pem_encoded
+        logger.info(request_data)
+        request_data["private_key"] = private_key
+        request_data["display_name"] = cert_name
+		
+        logger.info(request_data)
+        cert_id = get_certificate_id_with_name(module,manager_url, NSX_USER, NSX_PASSWORD, validate_certs,cert_name )
+        import_cert = import_certificate(module,manager_url,NSX_USER,NSX_PASSWORD, validate_certs, request_data,cert_id)
+        cert_id = get_certificate_id_with_name(module,manager_url, NSX_USER, NSX_PASSWORD, validate_certs,cert_name )
+        logger.info(cert_id)
+        register_cert3 = string.replace(register_cert2, "CERTIFICATE-ID", cert_id)
+        (sshin5,sshout5,ssherr5)=  pi.exec_command(register_cert3)
+        logger.info(sshout5.read())
+        module.exit_json(changed= True, msg= "Successuflly Created the SelfSigned Certificate with %s" %(cert_id))
+        
+
+    except Exception as err:
+        logger.info("Error Occured: {}".format(err))
+        module.fail_json(changed = False, msg = "Error Occured:%s" %(err))
+        
+def import_certificate(module,manager_url, NSX_USER, NSX_PASSWORD, validate_certs,request_data,cert_id):
+    request_obj = json.dumps(request_data)
+    if cert_id is None:
+            try:
+                if cert_id:
+                    print("Certificate Already Exists with that name %s" %(cert_id))                    
+                (rc, resp) = request(manager_url+ '/trust-management/certificates?action=import', data=request_obj, headers=headers, method='POST',
+                                url_username=NSX_USER, url_password=NSX_PASSWORD, validate_certs=validate_certs, ignore_errors=True)
+                logger.info("Successfully Imported the Certificate")
+            except Exception as err:
+                module.fail_json(changed=False,msg="Failed to Import the Certificate.Error:%s." % (to_native(err)))
+
+
+
+
+def get_certificate_id_with_name(module,manager_url, NSX_USER, NSX_PASSWORD, validate_certs,cert_name ):
+    
+    try:
+      (rc, resp) = request(manager_url+'/trust-management/certificates', headers=dict(Accept='application/json'),
+                      url_username=NSX_USER, url_password=NSX_PASSWORD, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+       print err
+    for result in resp['results']:
+        if result.__contains__('display_name') and result['display_name'] == cert_name:
+            return result['id']
+    
+	
+
+def main():
+    logger.info("entered into main")
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(hostname = dict(required=True, type= 'str'),
+			 username = dict(required=True, type= 'str'),
+			 password = dict(required=True, type= 'str'),
+                       NSX_MANAGER_IP_ADDRESS =dict(required=True, type= 'str'),
+                       NSX_MANAGER_COMMONNAME =dict(required=True, type= 'str'),
+                       NSX_PASSWORD=dict(required=True, type='str'),
+					   NSX_USER=dict(required=True, type='str'),
+		       validate_certs= dict(required=True, type= 'bool'),
+			    cert_name = dict(required=True, type= 'str'))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)  
+    pi = None
+    request_data ={}
+    headers = dict(Accept="application/json")
+    headers['Content-Type'] = 'application/json'
+    NSX_MANAGER_COMMONNAME = module.params["NSX_MANAGER_COMMONNAME"]
+    NSX_MANAGER_IP_ADDRESS = module.params["NSX_MANAGER_IP_ADDRESS"]
+    NSX_USER = module.params["NSX_USER"]
+    NSX_PASSWORD = module.params["NSX_PASSWORD"]
+    cert_name = module.params["cert_name"]
+    validate_certs = module.params["validate_certs"]   
+    manager_url = 'https://{}/api/v1'.format(NSX_MANAGER_IP_ADDRESS)
+    try:
+       	
+	pi = paramiko.client.SSHClient()
+	pi.load_system_host_keys()
+	pi.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
+	pi.connect(module.params["hostname"], 22, module.params["username"],module.params["password"])
+        logger.info('Esxi host connection succeed...........')
+        Self_Signed_Cert(pi,module,request_data,NSX_MANAGER_COMMONNAME,NSX_MANAGER_IP_ADDRESS,NSX_USER,NSX_PASSWORD,validate_certs,cert_name,manager_url)        
+    except Exception as err:
+	logger.info("Error Occured1: {}".format(err))
+        module.fail_json(changed=False, msg= "Error Occured : %s" %(err))
+	
+      
+if __name__ == "__main__":
+        main()

--- a/nsxt/nsxt_selfsigned.py
+++ b/nsxt/nsxt_selfsigned.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 import paramiko
 import string

--- a/nsxt/nsxt_selfsigned.py
+++ b/nsxt/nsxt_selfsigned.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright 2016 VMware, Inc.  All rights reserved.
-
-# Portions Copyright (c) 2015 VMware, Inc. All rights reserved.
 #
-# This file is part of Ansible
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 import paramiko
 import string

--- a/nsxt/nsxt_ssh_details.py
+++ b/nsxt/nsxt_ssh_details.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+
+
+
+import json
+import yaml
+import subprocess
+## LOGGER
+import logging
+logger = logging.getLogger('chaperone_details')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+
+    
+def main():
+    module = AnsibleModule(argument_spec=dict(), supports_check_mode=True)
+    cmd = ["""ip address | grep 'ens160'| grep 'inet' | awk '{print $2}'"""]
+    output =subprocess.check_output(cmd,shell=True)
+    output = output.rstrip("\n")
+    rest = output.replace("/24","")
+    cmd1 = ["whoami"]
+    output1 = subprocess.check_output(cmd1,shell=True)
+    module.exit_json(changed=True, hostname=rest, username = output1.rstrip("\n"), msg='Got cert details')
+
+    
+        
+    
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/nsxt/nsxt_ssh_details.py
+++ b/nsxt/nsxt_ssh_details.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-
-
-
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
 import json
 import yaml

--- a/nsxt/nsxt_ssh_details.py
+++ b/nsxt/nsxt_ssh_details.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 import json
 import yaml

--- a/nsxt/nsxt_superuser.py
+++ b/nsxt/nsxt_superuser.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#__author__ = 'VJ49'
+
+import paramiko
+import time
+import string
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+
+import logging
+logger = logging.getLogger('vswitch')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+
+create_cert = 'openssl req -newkey rsa:2048 -x509 -nodes -keyout '"'$NSX_SUPERUSER_KEY_FILE'"' -new -out '"'$NSX_SUPERUSER_CERT_FILE'"' -subj /CN=pks-nsx-t-superuser -extensions client_server_ssl -config <(cat /etc/ssl/openssl.cnf <(printf "[client_server_ssl]\nextendedKeyUsage = clientAuth\n")) -sha256 -days 730'
+
+search_pemcode = """awk '{printf "%s\\n", $0}' $NSX_SUPERUSER_CERT_FILE"""
+
+cert_reg = """cat <<END
+  {
+    "display_name": "$PI_NAME",
+    "pem_encoded": pemcode
+  }
+END"""   
+
+
+register_cert_curl ="""curl -k -X POST 'https://${NSX_MANAGER}/api/v1/trust-management/certificates?action=import' -u '$NSX_USER:$NSX_PASSWORD' -H 'content-type: application/json' -d '$register_cert'"""
+					   
+					 
+					   
+pi_request="""cat <<END
+  {
+    "display_name": "$PI_NAME",
+    "name": "$PI_NAME",
+    "permission_group": "superusers",
+    "certificate_id": "$CERTIFICATE_ID",
+    "node_id": "$NODE_ID"
+  }
+END"""
+
+pi_request_curl = """curl -k -X POST \
+  "https://${NSX_MANAGER}/api/v1/trust-management/principal-identities" \
+  -u "$NSX_USER:$NSX_PASSWORD" \
+  -H 'content-type: application/json' \
+  -d  '$pi_request' """
+
+
+verify = """curl -k -X GET \
+"https://${NSX_MANAGER}/api/v1/trust-management/principal-identities" \
+--cert $(pwd)/"$NSX_SUPERUSER_CERT_FILE" \
+--key $(pwd)/"$NSX_SUPERUSER_KEY_FILE" """
+
+
+def SuperUser(module,pi,NSX_MANAGER,NSX_USER,NSX_PASSWORD,PI_NAME,validate_certs,NSX_SUPERUSER_CERT_FILE,NSX_SUPERUSER_KEY_FILE,NODE_ID,manager_url):
+    create_cert1 = string.replace(create_cert, "$NSX_SUPERUSER_KEY_FILE",NSX_SUPERUSER_KEY_FILE)
+    create_cert2 = string.replace(create_cert1, "$NSX_SUPERUSER_CERT_FILE",NSX_SUPERUSER_CERT_FILE)
+
+    search_pemcode1 = string.replace(search_pemcode, "$NSX_SUPERUSER_CERT_FILE",NSX_SUPERUSER_CERT_FILE)
+    logger.info(search_pemcode1)
+
+	
+
+    
+    register_cert_curl1 = string.replace(register_cert_curl, "${NSX_MANAGER}",NSX_MANAGER)
+    register_cert_curl2 = string.replace(register_cert_curl1, "$NSX_USER",NSX_USER)
+    register_cert_curl3 = string.replace(register_cert_curl2, "$NSX_PASSWORD",NSX_PASSWORD)  
+    try:
+
+        (sshin1, sshout1, ssherr1) = pi.exec_command(create_cert2)
+        logger.info(create_cert2)
+        logger.info(sshout1.read())
+        (sshin,sshout,ssherr) = pi.exec_command(search_pemcode1)
+        pem_code_out = repr(sshout.read())
+        pem_code_out = pem_code_out.replace("'",'"')
+        logger.info("Pemcode:{}".format(pem_code_out))
+
+        register_cert1 = string.replace(cert_reg, "$PI_NAME", PI_NAME)
+        register_cert1 = string.replace(register_cert1, "pemcode", pem_code_out)
+        (sshin2, sshout2, ssherr2) = pi.exec_command(register_cert1)
+        register_cert_out=sshout2.read()
+        logger.info(register_cert_out)
+        logger.info(ssherr2)
+
+        register_cert_curl4 = string.replace(register_cert_curl3, "$register_cert",register_cert_out)
+        logger.info(register_cert_curl4)
+        (sshin3, sshout3, ssherr3) = pi.exec_command(register_cert_curl4)
+        output = sshout3.read()
+	logger.info(output)
+
+        cert_id = get_certificate_id_with_name(manager_url, NSX_USER, NSX_PASSWORD, validate_certs,PI_NAME )
+        logger.info(cert_id)
+
+        pi_request1 = string.replace(pi_request,"$PI_NAME",PI_NAME)
+        pi_request2 = string.replace(pi_request1,"$CERTIFICATE_ID", cert_id)
+        pi_request3 = string.replace(pi_request2, "$NODE_ID",NODE_ID)
+        (sshin4,sshout4,ssherr4) = pi.exec_command(pi_request3)
+        pi_request_out = sshout4.read()
+        logger.info(pi_request_out)
+      
+        pi_request_curl1 = string.replace(pi_request_curl, "$NSX_USER", NSX_USER)
+        pi_request_curl2 = string.replace(pi_request_curl1, "${NSX_MANAGER}", NSX_MANAGER)
+        pi_request_curl3 = string.replace(pi_request_curl2, "$NSX_PASSWORD", NSX_PASSWORD)
+        pi_request_curl4 = string.replace(pi_request_curl3, "$pi_request", pi_request_out)
+        logger.info(pi_request_curl4)
+        (sshin5, sshout5,ssherr5) = pi.exec_command(pi_request_curl4)
+        logger.info(sshout5.read())
+        
+        verify1 = string.replace(verify, "${NSX_MANAGER}", NSX_MANAGER)
+        verify2 = string.replace(verify1, "$NSX_SUPERUSER_CERT_FILE", NSX_SUPERUSER_CERT_FILE)
+        verify3 = string.replace(verify2,"$NSX_SUPERUSER_KEY_FILE" , NSX_SUPERUSER_KEY_FILE)
+
+        (sshin6,sshout6,ssherr6) = pi.exec_command(verify3)
+        logger.info(sshout6.read())
+	module.exit_json(changed=True,msg ="Successfully Created")
+
+    except Exception as err:
+        logger.info("Error occured at Super User Creation: {}".format(err))
+	module.fail_json(chagned=False, msg = "Error at Super User Creation:{}".format(err))
+        
+
+def get_certificate_id_with_name(manager_url, NSX_USER, NSX_PASSWORD, validate_certs,PI_NAME ):
+    try:
+        (rc, resp) = request(manager_url+'/trust-management/certificates', headers=dict(Accept='application/json'),
+                      url_username=NSX_USER, url_password=NSX_PASSWORD, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+        logger.info(err)
+	module.fail_json(msg= "Error at getting Certificate")
+    for result in resp['results']:
+        if result.__contains__('display_name') and result['display_name'] == PI_NAME:
+            return result['id']
+    
+	
+
+def main():
+    logger.info("entered into main")
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(hostname = dict(required=True, type= 'str'),
+			 username = dict(required=True, type= 'str'),
+			 password = dict(required=True, type= 'str'),
+                       NSX_MANAGER =dict(required=True, type= 'str'),
+                       NSX_USER =dict(required=True, type= 'str'),
+                       NSX_PASSWORD=dict(required=True, type='str'),
+		       validate_certs= dict(required=True, type= 'bool'),
+                       PI_NAME=dict(required=True, type='str'))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)  
+    logger.info("after module")       
+    NSX_MANAGER = module.params["NSX_MANAGER"]
+    NSX_USER = module.params["NSX_USER"]
+    NSX_PASSWORD = module.params["NSX_PASSWORD"]
+    PI_NAME = module.params["PI_NAME"]
+    validate_certs = module.params["validate_certs"]   
+    NSX_SUPERUSER_CERT_FILE = "/home/vmware/pks-nsx-t-superuser.crt"
+    NSX_SUPERUSER_KEY_FILE = "/home/vmware/pks-nsx-t-superuser.key"
+    NODE_ID = "$(cat /proc/sys/kernel/random/uuid)"
+    manager_url = 'https://{}/api/v1'.format(NSX_MANAGER)      
+
+    pi = None
+    try:
+        logger.info("hii")	
+	pi = paramiko.client.SSHClient()
+	pi.load_system_host_keys()
+	pi.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
+	pi.connect(module.params["hostname"], 22,module.params["username"],module.params["password"])
+	logger.info('Esxi host connection succeed...........')
+    	SuperUser(module,pi,NSX_MANAGER,NSX_USER,NSX_PASSWORD,PI_NAME,validate_certs,NSX_SUPERUSER_CERT_FILE,NSX_SUPERUSER_KEY_FILE,NODE_ID,manager_url)
+    except Exception as err:
+        logger.info("Error occured: {}".format(err))
+        module.fail_json(changed=False, msg = "Error occured:{}".format(err))
+	
+      
+if __name__ == "__main__":
+        main()

--- a/nsxt/nsxt_superuser.py
+++ b/nsxt/nsxt_superuser.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#__author__ = 'VJ49'
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 
 import paramiko
 import time

--- a/nsxt/nsxt_superuser.py
+++ b/nsxt/nsxt_superuser.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 
 import paramiko

--- a/nsxt/nsxt_transport_node_details.py
+++ b/nsxt/nsxt_transport_node_details.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 
 import yaml

--- a/nsxt/nsxt_transport_node_details.py
+++ b/nsxt/nsxt_transport_node_details.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#__author__ = 'VJ49'
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_transport_node_details.py
+++ b/nsxt/nsxt_transport_node_details.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#__author__ = 'VJ49'
+
+import yaml
+import yamlordereddictloader
+from collections import OrderedDict
+
+import logging
+logger = logging.getLogger('vswitch')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+        ),
+        supports_check_mode=True
+    )
+
+    final_dict = {}
+    sub_dict = {}
+    main_dict = {}
+    main_list= list()
+    stream1 = open('/var/lib/chaperone/answerfile.yml', 'r')    
+    dict1 = yaml.load(stream1, Loader=yamlordereddictloader.Loader)
+
+    try:
+        for data in dict1:
+            if data.startswith('check_edge_node') == True:
+                sub_dict[data] = dict1[data]
+        for content in dict1: 
+            if content.startswith('esxi_compute') == True:
+                if 'host' in content and 'ip' in content:
+                    main_dict["ip_address"]=dict1[content]
+                    logger.info(main_dict)
+                if 'host' in content and 'vmnic' in content:
+                    main_dict["vmnic"]=dict1[content]
+                    logger.info(main_dict)
+                    main_list.append(main_dict)
+                    main_dict={}
+        #logger.info(main_list)
+        #logger.info(main_dict)             
+        final_dict['transport_host_nodes']=main_list
+	module.exit_json(changed=True, id=final_dict, msg= "Successfully got the information")
+
+    except Exception as err:
+        module.fail_json(changed=False, msg= "Failure: %s" %(err))
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/nsxt/nsxt_transport_node_edge_details.py
+++ b/nsxt/nsxt_transport_node_edge_details.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 
 import yaml

--- a/nsxt/nsxt_transport_node_edge_details.py
+++ b/nsxt/nsxt_transport_node_edge_details.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#__author__ = 'VJ49'
+
+import yaml
+import yamlordereddictloader
+from collections import OrderedDict
+
+import logging
+logger = logging.getLogger('vswitch')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(funcName)s: %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+
+
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+        ),
+        supports_check_mode=True
+    )
+
+    final_dict = {}
+    sub_dict = {}
+    main_dict = {}
+    main_list= list()
+    stream1 = open('/var/lib/chaperone/answerfile.yml', 'r')    
+    dict1 = yaml.load(stream1, Loader=yamlordereddictloader.Loader)
+
+    try:
+        for data in dict1:
+            if data.startswith('check_edge_node') == True:
+                sub_dict[data] = dict1[data]
+        for count in range(len(sub_dict)):
+            hostname = str(count+1) + "_host_name"
+            tnnode = "_tn_node"+ str(count+1)+ "_name"
+            for content in dict1: 
+                if content.startswith('nsx_edge') == True:
+                    if hostname in content:
+                        main_dict["host_name"]=dict1[content]
+                        logger.info(main_dict)
+                    if tnnode in content:
+                        main_dict["node_name"]=dict1[content]
+                        #logger.info('Node_name {}'.format(dict1[content]))
+                        logger.info(main_dict)
+                        main_list.append(main_dict)
+                        main_dict={}
+        #logger.info(main_list)
+        #logger.info(main_dict)             
+        final_dict['transport_edge_nodes']=main_list
+	module.exit_json(changed=True, id=final_dict, msg= "Successfully got the information")
+
+    except Exception as err:
+        module.fail_json(changed=False, msg= "Failure: %s" %(err))
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/nsxt/nsxt_transport_node_edge_details.py
+++ b/nsxt/nsxt_transport_node_edge_details.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
-#__author__ = 'VJ49'
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 
 import yaml
 import yamlordereddictloader

--- a/nsxt/nsxt_vcenter_moids.py
+++ b/nsxt/nsxt_vcenter_moids.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# coding=utf-8
+#
+# Copyright © 2015 VMware, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions
+# of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+__author__ = 'VJ49'
+
+from pyVmomi import vim, vmodl
+from pyVim import connect
+from pyVim.connect import SmartConnect, SmartConnectNoSSL
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+
+from ansible.module_utils.basic import *
+
+import logging
+logger = logging.getLogger('Vcenter Moids')
+hdlr = logging.FileHandler('/var/log/chaperone/ChaperoneNSXtLog.log')
+formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr) 
+logger.setLevel(10)
+
+""" 
+    VIM_TYPES = {'datacenter': [vim.Datacenter],
+             'dvs_name': [vim.dvs.VmwareDistributedVirtualSwitch],
+             'datastore_name': [vim.Datastore],
+             'resourcepool_name': [vim.ResourcePool],
+             'portgroup_name': [vim.dvs.DistributedVirtualPortgroup, vim.Network]} """
+
+
+def get_all_objs(module,content, vimtype):
+    obj = {}
+    container = content.viewManager.CreateContainerView(content.rootFolder,
+                                                         vimtype, True)
+    for managed_object_ref in container.view:
+        obj.update({managed_object_ref: managed_object_ref.name})
+    return obj
+
+
+def find_object_by_name(module,content, object_name):
+    try:
+    	if(object_name == module.params['datacenter']):
+    	    vmware_objects = get_all_objs(module,content,[vim.Datacenter])
+    	elif (object_name == module.params['cluster']):
+    	    vmware_objects = get_all_objs(module,content,[vim.ComputeResource])
+    	elif (object_name == module.params['datastore']):
+            vmware_objects = get_all_objs(module,content,[vim.Datastore])
+    	elif (object_name == module.params['portgroup1'] or module.params['portgroup2'] or module.params['portgroup3'] ):
+            vmware_objects = get_all_objs(module,content,[vim.dvs.DistributedVirtualPortgroup, vim.Network])
+ 
+    	for object in vmware_objects:
+            if object.name == object_name:
+            	logger.info('object: %s',object.name)
+            	return object
+    	return None
+    except Exception as err:
+       module.fail_json(changed=False, msg= "Error Occured while Finding the Object by name. Error is %s" %(to_native(err)))
+
+
+
+
+
+def main():
+  argument_spec = vmware_argument_spec()
+ 
+  argument_spec.update(
+        dict(hostname= dict(required=True, type='str'),
+            username=dict(required=True, type='str'),
+            password=dict(required=True, type='str'),
+            datacenter=dict(required=True, type='str'),
+            cluster=dict(required=True, type='str'),
+            datastore=dict(required=True,type='str'),
+            portgroup1= dict(required=True,type='str'),
+            portgroup2= dict(required=True, type='str'),
+            portgroup3=dict(required=True, type='str')))
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+  try:
+	logger.info("Trying to connect to VCENTER SERVER . . .")
+	si = SmartConnectNoSSL(host=module.params['hostname'],
+						   user=module.params['username'],
+						   pwd=module.params['password'],
+						   port=443)
+        logger.info("Connected to VCENTER SERVER !")
+  except IOError, e:
+	#pass
+	#atexit.register(Disconnect, si)
+	logger.info("Connection failed {0}")
+        module.fail_json(changed=False, msg="Failed to connect vCenter")
+  content = si.RetrieveContent()
+
+  datacenter= module.params['datacenter']
+  cluster= module.params['cluster']
+  datastore= module.params['datastore']
+  portgroup1= module.params['portgroup1']
+  portgroup2= module.params['portgroup2']
+  portgroup3= module.params['portgroup3']
+
+  try:
+  	datacenter_mo = find_object_by_name(module,content, datacenter)
+  	datacenter_moid =  datacenter_mo._moId
+  	cluster_mo = find_object_by_name(module,content, cluster)
+  	cluster_moid = cluster_mo._moId
+  	datastore_mo = find_object_by_name(module,content, datastore)
+  	datastore_moid = datastore_mo._moId
+  	portgroup1_mo = find_object_by_name(module,content, portgroup1)
+  	portgroup1_moid = portgroup1_mo._moId
+  	portgroup2_mo = find_object_by_name(module,content, portgroup2)
+  	portgroup2_moid = portgroup2_mo._moId
+  	portgroup3_mo = find_object_by_name(module,content, portgroup3)
+ 	portgroup3_moid = portgroup3_mo._moId
+        #module.exit_json(changed=True, msg= "success")
+  	module.exit_json(changed=True,datacenter_id=datacenter_moid,cluster_id=cluster_moid,datastore_id=datastore_moid, portgroup1_id=portgroup1_moid,portgroup2_id=portgroup2_moid,portgroup3_id=portgroup3_moid,
+                            msg= "datacenter:%s, cluster:%s, datastore:%s, portgroup1:%s, portgroup2:%s, portgroup3:%s" %(datacenter_moid, cluster_moid, datastore_moid, portgroup1_moid, portgroup2_moid, portgroup3_moid))
+  except Exception as err:
+	module.fail_json(changed=False, msg="Error Occured:%s" %err) 
+    
+if __name__ == '__main__':
+    main()
+

--- a/nsxt/nsxt_vcenter_moids.py
+++ b/nsxt/nsxt_vcenter_moids.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright © 2015 VMware, Inc. All Rights Reserved.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions
-# of the Software.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-# TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
-# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 
-__author__ = 'VJ49'
 
 from pyVmomi import vim, vmodl
 from pyVim import connect

--- a/nsxt/nsxt_vcenter_moids.py
+++ b/nsxt/nsxt_vcenter_moids.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python
-#
-# Copyright © 2015 VMware, Inc. All Rights Reserved.
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+# -*- coding: utf-8 -*-
+# Copyright © 2019 VMware, Inc. All Rights Reserved.
+
+# SPDX-License-Identifier: Apache-2.0
 
 
 from pyVmomi import vim, vmodl


### PR DESCRIPTION
The utility modules for NSX-T include:
- Create nsxt self-signed and  superuser certificates
- Fetch details of controller, edge node, fabric nodes, transport node(host,edge), vcenter_moids
- nsxt_ssh_details.py  - To fetch chaperone host information(SSH) to execute certificate (openssl) commands on localhost (as ansible run_command did not work with openssl commands)

Signed-off-by: Gayathri Palanimuthu (c) <gpalanimuthu@vmware.com>